### PR TITLE
重複チェック&INSERT

### DIFF
--- a/backend/src/controllers/registerController.ts
+++ b/backend/src/controllers/registerController.ts
@@ -130,38 +130,46 @@ export const registerUser = async (
 		return (reply.code(400).send(validationResult.error));
 	}
 
-	// emailの重複チェック
-	const emailDupResult = await checkEmailDuplicate(request.body.email);
-	if (!emailDupResult.success) {
-		return reply.code(400).send(emailDupResult.error);
-	}
-
-	//nameの重複チェック
-	const nameDupResult = await checkNameDuplicate(request.body.name);
-	if (!nameDupResult.success) {
-		return (reply.code(400).send(nameDupResult.error));
-	}
-
-	// userDBにINSERT
-	const passwordHash = await bcrypt.hash(request.body.password, 10);
-	const createdUser = await prisma.user.create({
-		data: {
-			name: request.body.name,
-			email: request.body.email,
-			password: passwordHash
+	try {
+		// emailの重複チェック
+		const emailDupResult = await checkEmailDuplicate(request.body.email);
+		if (!emailDupResult.success) {
+			return reply.code(400).send(emailDupResult.error);
 		}
-	});
 
-	// ダミーレスポンス成功時 (201)
-	const successResponse: RegisterSuccessResponse = {
-		userId: createdUser.id
-	};
+		//nameの重複チェック
+		const nameDupResult = await checkNameDuplicate(request.body.name);
+		if (!nameDupResult.success) {
+			return (reply.code(400).send(nameDupResult.error));
+		}
 
-	//TODO:ここからログイン処理
-	// 1. セッションIDを生成
-	// 2. セッションIDとuserIDを紐づけて保存
-	// 3. クッキーに設定し、レスポンスを返す
+		// userDBにINSERT
+		const passwordHash = await bcrypt.hash(request.body.password, 10);
+		const createdUser = await prisma.user.create({
+			data: {
+				name: request.body.name,
+				email: request.body.email,
+				password: passwordHash
+			}
+		});
 
-	//TODO: クッキーにセッションIDをセットしてレスポンスを返す
-	return (reply.code(201).send(successResponse));
+		// ダミーレスポンス成功時 (201)
+		const successResponse: RegisterSuccessResponse = {
+			userId: createdUser.id
+		};
+
+		//TODO:ここからログイン処理
+		// 1. セッションIDを生成
+		// 2. セッションIDとuserIDを紐づけて保存
+		// 3. クッキーに設定し、レスポンスを返す
+
+		//TODO: クッキーにセッションIDをセットしてレスポンスを返す
+		return (reply.code(201).send(successResponse));
+
+	} catch (err) {
+		request.log?.error?.(err);
+		return (reply.code(500).send({
+			message: '予期しないエラーが発生しました。時間をおいて再度お試しください'
+		}));
+	}
 };

--- a/backend/src/types/register.ts
+++ b/backend/src/types/register.ts
@@ -27,9 +27,16 @@ export interface RegisterErrorResponse {
 }
 
 /**
+ * POST /api/register サーバーエラーレスポンス型 (500)
+ */
+export interface RegisterServerErrorResponse {
+	message: string;
+}
+
+/**
  * POST /api/register ルートの型定義
  */
 export type RegisterRoute = {
 	Body: RegisterRequest;
-	Reply: RegisterSuccessResponse | RegisterErrorResponse;
+	Reply: RegisterSuccessResponse | RegisterErrorResponse | RegisterServerErrorResponse;
 };


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
- email / name の重複チェック
- パスワードのハッシュ化
- DB INSERT

## 変更内容
- 変更1
- 変更2

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
以下を実行して、DBにuserを保存されてることを確認してみてほしいです。
```bash
curl -X POST http://localhost:3000/api/register \
  -H "Content-Type: application/json" \
  -d '{
    "name": "testuser",
    "email": "test@example.com",
    "password": "12345ABCabc"
  }'
  
  curl -X POST http://localhost:3000/api/register \
  -H "Content-Type: application/json" \
  -d '{
    "name": "test_00",
    "email": "test00@example.com",
    "password": "12345ABCabc"
    }'

  
  #NG ユーザー名の重複
  curl -X POST http://localhost:3000/api/register \
  -H "Content-Type: application/json" \
  -d '{
    "name": "testuser",
    "email": "aaaaa@example.com",
    "password": "12345ABCabc"
  }'
  
   #NG メルアドの重複
  curl -X POST http://localhost:3000/api/register \
  -H "Content-Type: application/json" \
  -d '{
    "name": "aaaaa",
    "email": "test@example.com",
    "password": "12345ABCabc"
  }'
```

(以下は、やりたい人だけ)
DBが起動していないなどの理由で、処理に失敗した場合のレスポンス
1. 普段通りdocker-composeを起動
2. db コンテナだけ停止`docker-compose stop db`
3. その状態で POST /api/register を叩く
```
curl -X POST http://localhost:3000/api/register \
  -H "Content-Type: application/json" \
  -d '{
    "name": "testuser",
    "email": "test@example.com",
    "password": "12345ABCabc"
  }'
  ```
  4. すると、`{"message":"予期しないエラーが発生しました。時間をおいて再度お試しください"}`が帰ってくる
  
## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->
```bash
docker compose exec -it backend sh

npx prisma studio
```
上記を実行した後 http://localhost:5555 を開くと、テーブルの中身が見れます。
パスワードがハッシュ化された状態で保存されており、同じパスワードでも異なるハッシュ値になっていることが確認できると思います。


## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->
アカウント作成できたら、ログインした状態でホーム画面に遷移にするようにするので、アカウント作成処理にログイン処理が内包されることになります。
ちな、ログイン処理は今後実装します。リファクタリングも後でします。

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
- [x] コンパイルできますか？
- [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [x] セグフォ・リーク・free忘れはありませんか？
