### PR TITLE
 sessionIDからuserIDを取得する関数作成

### DIFF
--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -1,0 +1,33 @@
+import type { FastifyRequest } from 'fastify';
+import { prisma } from './prisma';
+
+/**
+ * sessionIDからuser_idを取得し、返す
+ * sessionIDがない・無効なら、nullを返す
+ */
+export const getUserIdFromSessionId = async (sessionId: string | undefined): Promise<number | null> => {
+	if (!sessionId)
+		return null;
+
+	const session = await prisma.session.findUnique({
+		where: { id: sessionId },
+		select: { user_id: true },
+	})
+
+	if (!session)
+		return null;
+
+	return session.user_id;
+}
+
+
+/**
+ * FastifyRequestからCookie(session_id) を読み取り、user_id を返す。
+ * sessionIDがない・無効なら、nullを返す
+ */
+export const getUserIdFromRequest = async (request: FastifyRequest): Promise<number | null> => {
+	const cookieName = 'session_id'
+	const sessionId = request.cookies?.[cookieName]
+
+	return getUserIdFromSessionId(sessionId)
+}


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
ログイン中のユーザーのuser_idを取得したいときに使える関数を用意しました。

## 変更内容

-  sessionIDからuserIDを取得する関数(`getUserIdFromSessionId`)
- リクエストからuserIDを取得する関数(`getUserIdFromRequest`)
の２つを作成。

基本的には`getUserIdFromRequest`を使ってもらうことになるかなと思います。

使用例
 ```ts
import { getUserIdFromRequest } from '../lib/auth'

export const meProfile = async (request, reply) => {

        //requestを引数に、実行
	const userId = await getUserIdFromRequest(request)
	if (!userId) // SessionIDがない or 該当するセッションがない場合はnullが返ってくる
　　　　//userIDが見つからない場合の処理
		~ ~ ~
	// userId を使った処理
}

```

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
特にないです。

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->


## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->
ログイン中のユーザーの情報を取得したい・変更したい等の処理に使用してください。

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
- [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [x] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
