### PR TITLE
feat: WebSocketでルーム別のリアルタイムメッセージ機能の実装

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,11 +1,11 @@
-import Fastify from 'fastify';
-import cors from '@fastify/cors';
-import cookie from '@fastify/cookie';
-import websocket from '@fastify/websocket';
-import { userRoutes } from './routes/userRoutes';
-import { authRoutes } from './routes/authRoutes';
-import { roomRoutes } from './routes/roomRoutes';
-import { handleConnection } from './ws/connectionHandler';
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import cookie from "@fastify/cookie";
+import websocket from "@fastify/websocket";
+import { userRoutes } from "./routes/userRoutes";
+import { authRoutes } from "./routes/authRoutes";
+import { roomRoutes } from "./routes/roomRoutes";
+import { handleConnection } from "./ws/connectionHandler";
 
 const fastify = Fastify({
 	logger: true,
@@ -30,8 +30,8 @@ fastify.register(authRoutes, { prefix: "/api" });
 fastify.register(roomRoutes, { prefix: "/api" });
 
 // WebSocketのルートを定義
-fastify.register(async (fastify) => {
-	fastify.get('/ws', { websocket: true }, (socket, request) => {
+fastify.register(async fastify => {
+	fastify.get("/ws", { websocket: true }, (socket, request) => {
 		handleConnection(socket);
 	});
 });

--- a/backend/src/types/room.ts
+++ b/backend/src/types/room.ts
@@ -59,4 +59,4 @@ export interface RoomClient {
 	socket: WebSocket;
 	userId: string;
 	roomId: string;
-};
+}

--- a/backend/src/ws/chatHandler.ts
+++ b/backend/src/ws/chatHandler.ts
@@ -1,11 +1,13 @@
-import { broadcastToRoom } from './roomManager';
-import { RoomClient } from '../types/room';
+import { broadcastToRoom } from "./roomManager";
+import { RoomClient } from "../types/room";
 
 export const handleChatMessage = (client: RoomClient, data: any) => {
-	console.log(`💬 Chat from ${client.userId} in room ${client.roomId}: ${data.text}`);
+	console.log(
+		`💬 Chat from ${client.userId} in room ${client.roomId}: ${data.text}`,
+	);
 
 	broadcastToRoom(client.roomId, {
-		type: 'chat',
+		type: "chat",
 		id: data.id,
 		sender: data.sender,
 		text: data.text,

--- a/backend/src/ws/connectionHandler.ts
+++ b/backend/src/ws/connectionHandler.ts
@@ -1,35 +1,46 @@
-import { WebSocket } from 'ws';
-import { RoomClient } from '../types/room';
-import { joinRoom, leaveRoom, broadcastToRoom } from './roomManager';
-import { handleChatMessage } from './chatHandler';
+import { WebSocket } from "ws";
+import { RoomClient } from "../types/room";
+import { joinRoom, leaveRoom, broadcastToRoom } from "./roomManager";
+import { handleChatMessage } from "./chatHandler";
 
 export const handleConnection = (socket: WebSocket) => {
 	let currentClient: RoomClient | null = null;
 
 	console.log("✅ Client connected");
 
-	socket.on('message', (rawMessage) => {
+	socket.on("message", rawMessage => {
 		try {
 			const data = JSON.parse(rawMessage.toString());
 			console.log("📥 Received: ", data);
 
-			if (data.type === 'join') {
-
-				if (!data.userId || typeof data.userId !== 'string' || data.userId.trim() === '') {
-					console.log('❌ Invalid userId:', data.userId);
-					socket.send(JSON.stringify({
-						type: 'error',
-						message: 'Invalid userId'
-					}));
-					return ;
+			if (data.type === "join") {
+				if (
+					!data.userId ||
+					typeof data.userId !== "string" ||
+					data.userId.trim() === ""
+				) {
+					console.log("❌ Invalid userId:", data.userId);
+					socket.send(
+						JSON.stringify({
+							type: "error",
+							message: "Invalid userId",
+						}),
+					);
+					return;
 				}
-	
-				if (!data.roomId || typeof data.roomId !== 'string' || data.roomId.trim() === '') {
-					socket.send(JSON.stringify({
-						type: 'error',
-						message: 'Invalid roomId'
-					}));
-					return ;
+
+				if (
+					!data.roomId ||
+					typeof data.roomId !== "string" ||
+					data.roomId.trim() === ""
+				) {
+					socket.send(
+						JSON.stringify({
+							type: "error",
+							message: "Invalid roomId",
+						}),
+					);
+					return;
 				}
 
 				if (currentClient) {
@@ -44,31 +55,35 @@ export const handleConnection = (socket: WebSocket) => {
 
 				joinRoom(currentClient);
 
-				socket.send(JSON.stringify({
-					type: 'joined',
-					roomId: data.roomId,
-					userId: data.userId,
-				}));
+				socket.send(
+					JSON.stringify({
+						type: "joined",
+						roomId: data.roomId,
+						userId: data.userId,
+					}),
+				);
 
 				broadcastToRoom(data.roomId, {
-					type: 'userJoined',
+					type: "userJoined",
 					userId: data.userId,
 				});
 
-				return ;
+				return;
 			}
 
 			if (!currentClient) {
 				console.error("❌ Not joined to any room");
-				socket.send(JSON.stringify({
-					type: 'error',
-					message: "Join a room first",
-				}));
+				socket.send(
+					JSON.stringify({
+						type: "error",
+						message: "Join a room first",
+					}),
+				);
 
-				return ;
+				return;
 			}
 
-			if (data.type === 'chat') {
+			if (data.type === "chat") {
 				handleChatMessage(currentClient, data);
 			}
 		} catch (error) {
@@ -76,10 +91,10 @@ export const handleConnection = (socket: WebSocket) => {
 		}
 	});
 
-	socket.on('close', () => {
+	socket.on("close", () => {
 		if (currentClient) {
 			broadcastToRoom(currentClient.roomId, {
-				type: 'userLeft',
+				type: "userLeft",
 				userId: currentClient.userId,
 			});
 
@@ -87,4 +102,4 @@ export const handleConnection = (socket: WebSocket) => {
 		}
 		console.log("🔌 Client disconnected");
 	});
-}
+};

--- a/backend/src/ws/roomManager.ts
+++ b/backend/src/ws/roomManager.ts
@@ -1,9 +1,9 @@
-import { WebSocket } from 'ws';
-import { RoomClient } from '../types/room';
+import { WebSocket } from "ws";
+import { RoomClient } from "../types/room";
 
 // キー：roomId (string)
 // 値: Set<RoomClient>
-const rooms = new Map<string, Set<RoomClient>>()
+const rooms = new Map<string, Set<RoomClient>>();
 
 export const joinRoom = (client: RoomClient) => {
 	// ルームが存在しなければ作成
@@ -17,13 +17,11 @@ export const joinRoom = (client: RoomClient) => {
 		console.log(`✅ User ${client.userId} joined room ${client.roomId}`);
 		console.log(`📈 Room ${client.roomId} now has ${room.size} members`);
 	}
-
 };
 
 export const leaveRoom = (client: RoomClient) => {
 	const room = rooms.get(client.roomId);
-	if (!room)
-		return ;
+	if (!room) return;
 
 	room.delete(client);
 	console.log(`👋 User ${client.userId} left room ${client.roomId}`);
@@ -41,7 +39,7 @@ export const broadcastToRoom = (roomId: string, message: any) => {
 	const room = rooms.get(roomId);
 	if (!room) {
 		console.log(`⚠️ Room ${roomId} not found`);
-		return ;
+		return;
 	}
 
 	const payload = JSON.stringify(message);
@@ -54,5 +52,7 @@ export const broadcastToRoom = (roomId: string, message: any) => {
 		}
 	});
 
-	console.log(`📤 Broadcasted to ${sentCount}/${room.size} clients in room ${roomId}`);
+	console.log(
+		`📤 Broadcasted to ${sentCount}/${room.size} clients in room ${roomId}`,
+	);
 };

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -17,18 +17,21 @@ const Game = () => {
 		const ws = createWebSocket();
 
 		ws.onopen = () => {
-			console.log('✅ WebSocket connected');
+			console.log("✅ WebSocket connected");
 
 			// TODO: ログイン機能実装後、実際のuserIdを使用
 			// TODO: URLパラメータからroomIdを取得
-			const tempUserId = 'user-' + Math.random().toString(36).substring(2, 9);
-			const tempRoomId = 'room-test-1';
+			const tempUserId =
+				"user-" + Math.random().toString(36).substring(2, 9);
+			const tempRoomId = "room-test-1";
 
-			ws.send(JSON.stringify({
-				type: 'join',
-				userId: tempUserId, // TODO: GET /api/me から取得
-				roomId: tempRoomId, // TODO: useParams() から取得
-			}));
+			ws.send(
+				JSON.stringify({
+					type: "join",
+					userId: tempUserId, // TODO: GET /api/me から取得
+					roomId: tempRoomId, // TODO: useParams() から取得
+				}),
+			);
 		};
 
 		ws.onmessage = event => {


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
WebSocketでルームごとのメッセージを配信

## 変更内容
- `roomManager.ts` 実装（ルーム管理ロジック）
  - `joinRoom`: WebSocket接続をルームに登録
  - `leaveRoom`: WebSocket接続をルームから削除
  - `broadcastToRoom`: ルーム内全員へのWebSocketメッセージを配信
- `RoomClient`型を `backend/src/types/room.ts` に統一
- `connectioHandler.ts` 更新（roomManager使用）
- `chatHandler.ts` 更新（broadcastToRoom使用）

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
- コンテナ立ち上げ：`docker compose down && docker compose up --build`
- 複数タブで [localhost:5173/game](url) にアクセス
- 同じルーム内でチャットメッセージの送受信確認
- コンテナを終了せず `Game.tsx` 23行目の `room-test-2`を `room-test-1` に変更して保存
- 新たに複数タブで [localhost:5173/game](url) にアクセス（新しいルームにアクセス）
- 別ルームにチャットメッセージが送信されないことを確認

![output_1080_fast](https://github.com/user-attachments/assets/16822db1-bc71-4ac8-8849-d55e4031e53b)

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->
- 型定義の配置（`backend/src/types/room.ts`）
- `roomManager.ts` は WebSocket専用のルーム管理です（REST APIのroomController.tsとは別物）
  - `roomController.ts`：ルーム作成など（データベース操作）
  - `roomManager.ts`：リアルタイム通信のルーム管理（チャットメッセージをルーム内に配信するなど）

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->
- 現在のは仮のルームID（`Game.tsx`にベタ書き）でテスト
- ログイン処理をしていないので、ブラウザのコンソールに`/api/me`のエラーが出ますが、正常な動作です

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->
- [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [x] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
