### PR TITLE
参加者側のルーム参加のエラーを直した

### DIFF
--- a/backend/src/controllers/roomController.ts
+++ b/backend/src/controllers/roomController.ts
@@ -22,7 +22,6 @@ import {
 import { updateReadyStatus } from "../services/roomService";
 import { getUserIdFromRequest } from "../lib/auth";
 import { broadcastToRoom } from "../ws/roomManager";
-import { tuple } from "zod";
 
 /*
  * POST /api/rooms ルーム作成

--- a/frontend/src/pages/Waiting.tsx
+++ b/frontend/src/pages/Waiting.tsx
@@ -182,20 +182,6 @@ const Waiting = () => {
 		};
 	}, [roomId, user?.id, token, navigate]);
 
-	// URL招待で参加したメンバーをルームに追加する
-	useEffect(() => {
-		if (!token || !user?.id || !roomId) return;
-		const joinRoomByToken = async () => {
-			try {
-				await roomApi.joinRoomByToken(token);
-				getRoomDetails();
-			} catch (error) {
-				console.error("Error", error);
-			}
-		};
-		joinRoomByToken();
-	}, [token, user?.id, roomId, getRoomDetails]);
-
 	const toggleRole = async (id: number) => {
 		// toggleするたびにAPIを叩く、そのプレイヤーのroleを変更する
 		const targetUser = users.find(user => user.id === id);


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
- 招待URLで参加したユーザーのロールトグルが相手画面に反映されない問題を修正。
- 招待参加時の joinRoomByToken と WebSocket JOIN のレースコンディション、および React Strict Mode による重複リクエストで発生する 500 エラーを解消。

## 変更内容

### フロントエンド (Waiting.tsx)
- 招待参加時は joinRoomByToken を先に実行し、成功後に WebSocket 接続するよう startConnection を導入
- Strict Mode による重複呼び出しを防ぐため hasJoinedRef を追加
- WebSocket の onerror を、接続前のエラーは console.warn、接続後のエラーは console.error に分岐
- useEffect の依存配列に token を追加
### バックエンド (roomController.ts)
- joinRoomByToken の catch 内で、既にメンバーの場合は 200 を返す冪等処理を追加（同時リクエスト時の 500 を回避）

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
- ホストがルームを作成し、招待URLをコピーして参加者に共有する
- 参加者が招待URLで参加し、参加者一覧に表示されることを確認する
- ホストが参加者のロール（プレイヤー/観戦者）をトグルし、参加者側の画面に即時反映されることを確認する
- 参加者側で 500 エラーが発生しないことを確認する（開発者ツールの Console / Network）

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->
- startConnection 内の joinRoomByToken → connect() の実行順序
- hasJoinedRef による重複呼び出し防止の実装
- バックエンドの joinRoomByToken の catch 内での冪等処理

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [ ] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
