### PR TITLE
未ログインで招待URLに入るとログイン画面にリダイレクト、ログイン後ルームに参加

### DIFF
--- a/frontend/src/features/auth/RequireGuest.tsx
+++ b/frontend/src/features/auth/RequireGuest.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation, type Location } from "react-router-dom";
 import Footer from "../../components/footer/Footer";
 import { useAuth } from "./useAuth";
 
 const RequireGuest = ({ children }: { children: ReactNode }) => {
 	const { isAuthenticated, refreshAuth } = useAuth();
+	const location = useLocation();
 
 	const [isChecking, setIsChecking] = useState(false);
 	const [isInitialized, setIsInitialized] = useState(false);
@@ -28,8 +29,10 @@ const RequireGuest = ({ children }: { children: ReactNode }) => {
 	const redirectEnabled =
 		import.meta.env.VITE_AUTH_REDIRECT_ENABLED === "true";
 
-	// リダイレクトが有効かつログイン済みの場合はホーム画面にリダイレクト
-	if (redirectEnabled && isAuthenticated) return <Navigate to="/" replace />;
+	// リダイレクトが有効かつログイン済みの場合はリダイレクト（招待URL由来なら元のページへ）
+	const from = (location.state as { from?: Location })?.from;
+	if (redirectEnabled && isAuthenticated)
+		return <Navigate to={from ?? "/"} replace />;
 
 	// /api/me確認中ならローディング表示
 	if (!isInitialized || isChecking) {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation, type Location } from "react-router-dom";
 import { authApi } from "../api/authApi";
 import { ApiError } from "../api/apiClient";
 import { useAuth } from "../features/auth/useAuth";
@@ -10,6 +10,7 @@ import BackButton from "../components/BackButton";
 
 const Login = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const { refreshAuth } = useAuth();
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
@@ -73,9 +74,8 @@ const Login = () => {
 				setServerError("ログインに失敗しました。再度お試しください。");
 				return;
 			}
-			//TODO: トーストの表示
-			//TODO: 元々アクセスしようとしていたページに戻す(?)
-			navigate("/");
+			const from = (location.state as { from?: Location })?.from;
+			navigate(from ?? "/", { replace: true });
 		} catch (err) {
 			// レスポンスの正規化
 			const result = normalizeErrResponse(err);

--- a/frontend/src/pages/SetupProfile.tsx
+++ b/frontend/src/pages/SetupProfile.tsx
@@ -60,7 +60,7 @@ const SetupProfile = () => {
 				setServerError("更新に失敗しました。再度お試しください。");
 				return;
 			}
-			navigate(from?.pathname ?? "/", { replace: true });
+			navigate(from ?? "/", { replace: true });
 		} catch (err) {
 			setServerError(normalizeErrResponse(err));
 		}


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->

- 未ログイン時に招待URL（/waiting/:id?token=xxx）へアクセスした場合、ログイン画面へリダイレクトし、ログイン成功後に元の招待URLのルームへ自動参加する


## 変更内容

- Login.tsx: useLocation を追加し、ログイン成功時に location.state.from があればそこへ遷移するよう変更（なければ従来通り / へ）
- SetupProfile.tsx: プロフィール設定完了後のリダイレクトで、from.pathname だけでなく from 全体（pathname + search + hash）を渡すよう変更し、招待URLの ?token= を維持
- RequireGuest.tsx: ログイン済みユーザーをログイン画面からリダイレクトする際、location.state.from があればそこへ遷移するよう変更（なければ従来通り / へ）


## テスト <!-- どのように確認(テスト)すればいいですか？ -->

- 招待URL経由のログイン: 未ログインで招待URLにアクセス → ログイン画面へ遷移 → ログイン成功後、該当ルームの待機画面に戻り、ルーム参加が完了すること
- 通常ログイン: 直接 /login にアクセスしてログイン → ホーム画面へ遷移すること
- プロフィール未完了ユーザー: 招待URL経由でログインし、プロフィール未完了 → プロフィール設定画面 → 設定完了後、招待URLのルームへ遷移し参加できること

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [ ] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
