### PR TITLE
ngrokでトンネリングできる

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,11 +7,14 @@ JWT_SECRET=your-secret-key-change-this-in-production
 # Backend
 PORT=3000
 
-# Frontend (HTTPS via Nginx)
-VITE_API_URL=https://oekakinomori.com
+# アプリのベースURL（ngrok 使用時は ngrok の URL、本番は oekakinomori.com）
+APP_URL=https://unweakening-cara-withdrawn.ngrok-free.dev
+
+# ngrok (ローカル開発用トンネル)
+NGROK_AUTHTOKEN=
 
 # google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=
-FRONTEND_URL=https://oekakinomori.com
+FRONTEND_URL=https://unweakening-cara-withdrawn.ngrok-free.dev

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-.PHONY: up down restart build logs ps
+.PHONY: up down restart build logs ps up-ngrok ngrok logs-ngrok url-ngrok setup
 
-up:
+# デフォルト: アプリ起動
+.DEFAULT_GOAL := up
+
+# .env がなければ backend/.env へのシンボリックリンクを作成（Docker Compose が自動読み込み）
+setup:
+	@if [ -f backend/.env ] && [ ! -f .env ]; then ln -sf backend/.env .env && echo "Created .env -> backend/.env"; fi
+
+up: setup
 	./scripts/start.sh
 
 down:
-	docker compose down
+	docker compose --profile ngrok down
 
 restart: down up
 
@@ -16,3 +23,16 @@ logs:
 
 ps:
 	docker compose ps
+
+up-ngrok: setup
+	docker compose --profile ngrok up -d
+
+ngrok: setup
+	docker compose --profile ngrok up -d ngrok
+
+logs-ngrok:
+	docker compose --profile ngrok logs -f ngrok
+
+# ngrok のトンネル URL を表示（Traffic Inspector API から取得）
+url-ngrok:
+	@curl -s http://localhost:4040/api/tunnels 2>/dev/null | grep -o '"public_url":"[^"]*"' | head -1 | cut -d'"' -f4 || curl -s http://localhost:4040/api/endpoints 2>/dev/null | grep -o '"url":"[^"]*"' | head -1 | cut -d'"' -f4 || echo "ngrok が起動していません。make ngrok を実行してください。"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=https://oekakinomori.com
+      - VITE_API_URL=${APP_URL:-https://unweakening-cara-withdrawn.ngrok-free.dev}
       - VITE_AUTH_REDIRECT_ENABLED=true # ログイン済みでログイン画面にアクセスしたらホームへリダイレクト
 
   backend:
@@ -28,7 +28,7 @@ services:
       - /app/node_modules
     environment:
       - DATABASE_URL=postgresql://oekaki:password@db:5432/oekaki_db
-      - FRONTEND_URL=https://oekakinomori.com
+      - FRONTEND_URL=${APP_URL:-https://unweakening-cara-withdrawn.ngrok-free.dev}
     depends_on:
       - db
 
@@ -42,6 +42,18 @@ services:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+
+  ngrok:
+    image: ngrok/ngrok:alpine
+    command: http https://nginx:443
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+    ports:
+      - "4040:4040"
+    depends_on:
+      - nginx
+    profiles:
+      - ngrok
 
 volumes:
   postgres_data:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,10 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
 	plugins: [react()],
 	server: {
-		allowedHosts: ["oekakinomori.com", "www.oekakinomori.com"],
+		allowedHosts: [
+			// "oekakinomori.com",
+			// "www.oekakinomori.com",
+			".ngrok-free.dev",
+		],
 	},
 });


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->

ngrok によるローカル開発用トンネルを追加し、Docker Compose で ngrok コンテナを起動できるようにした。また、ngrok 経由でのアクセスに対応するため、フロント・バックの URL 設定と Vite の allowedHosts を変更した。

## 変更内容

- docker-compose.yml: ngrok サービスを追加（profiles: [ngrok] でオプション起動）
- docker-compose.yml: frontend/backend の VITE_API_URL と FRONTEND_URL を APP_URL で切り替え可能に変更
- Makefile: setup, up-ngrok, ngrok, logs-ngrok, url-ngrok を追加
- Makefile: down に --profile ngrok を付与し、ngrok コンテナも停止するように変更
- Makefile: make のデフォルトターゲットを up に設定
- scripts/start.sh: backend/.env がある場合に .env シンボリックリンクを作成する処理を削除（Makefile の setup に移行）
- frontend/vite.config.ts: allowedHosts に .ngrok-free.dev を追加
- .env.example: APP_URL, NGROK_AUTHTOKEN を追加


## テスト <!-- どのように確認(テスト)すればいいですか？ -->

- make up でアプリが起動する
- make ngrok で ngrok コンテナが起動する
- make ngrok 実行後、make url-ngrok でトンネル URL が表示される
- make down で ngrok を含む全コンテナが停止する
- ngrok の URL にアクセスすると、フロントエンドが表示される
- ngrok 経由で Google OAuth ログインが動作する（GOOGLE_REDIRECT_URI の設定確認）

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->
- `http://localhost:4040/inspect/http`でAPIの確認もできます。

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [ ] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
