### PR TITLE
149 feat: ゲームの進行状況に応じてルームステータスを更新する

### DIFF
--- a/backend/src/ws/connectionHandler.ts
+++ b/backend/src/ws/connectionHandler.ts
@@ -350,6 +350,11 @@ export const handleConnection = (socket: WebSocket) => {
 						currentRound.drawer_id,
 					);
 
+					await prisma.room.update({
+						where: { id: Number(currentClient.roomId) },
+						data: { status: "PLAYING" },
+					});
+
 					drawerClient?.socket.send(
 						JSON.stringify({
 							type: WebSocketMessageType.ROUND_STARTED,

--- a/backend/src/ws/timerManager.ts
+++ b/backend/src/ws/timerManager.ts
@@ -1,3 +1,4 @@
+import { prisma } from "../lib/prisma";
 import {
 	broadcastToRoom,
 	endRound,
@@ -49,6 +50,11 @@ export const startTimer = (
 			if (isGameOver === null) return;
 			if (isGameOver) {
 				await finalizeGame(roomId);
+			} else {
+				await prisma.room.update({
+					where: { id: Number(roomId) },
+					data: { status: "WAITING" },
+				});
 			}
 			broadcastToRoom(roomId, {
 				type: WebSocketMessageType.ROUND_END,


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
- ラウンド開始時にルームステータスを "PLAYING" に更新
- ラウンド終了時（ゲーム継続中）にルームステータスを "WAITING" に更新

## 変更内容
### バックエンド
- `connectionHanlder.ts`
  - `ROUND_START` WebSocketメッセージの受信処理を行ったあと、開始合図のブロードキャスト直前にRoomステータスを `PLAYING` に更新
- `timerManager.ts`
  - タイマーが0以下になり、ゲームが続いている（ラウンドがの凝っている）場合、Roomのステータスを `WAITING` に更新

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
- Prisma studioでRoomテーブル内のプレイ中のRoomが状況に応じて更新されていること確認

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [x] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
