### PR TITLE
161 feat: PrepareおよびResult画面への再接続処理

### DIFF
--- a/frontend/src/pages/Waiting.tsx
+++ b/frontend/src/pages/Waiting.tsx
@@ -47,6 +47,15 @@ const Waiting = () => {
 			if (res.status === RoomStatus.PLAYING) {
 				navigate(`/game/${roomId}`);
 				return;
+			} else if (res.status === RoomStatus.RESULT) {
+				navigate(`/result/${roomId}`);
+				return;
+			} else if (
+				res.status === RoomStatus.WAITING &&
+				res.rounds?.length > 0
+			) {
+				navigate(`/prepare/${roomId}`);
+				return;
 			}
 			setIsHost(res.host_id === user?.id);
 			setHostId(res.host_id);


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
- Prepare画面およびResult画面でゲーム離脱した場合、招待URLから復帰できるように実装

## 変更内容
- `Waiting.tsx`
  - Roomステータスが `RESULT` の場合、Result画面にリダイレクト
  - Roomステータスが `WAITING` かつ `rounds` がひとつでも生成されている場合、Prepare画面にリダイレクト

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
- コンテナ立ち上げ
```bash
make down
make
make ngrok
```
- 2つのユーザーでログインし、ゲームルームを作成
  - Email: 好きなユーザーで
  - Password: `Password123`
- 片方のユーザーでPrepare画面、Result画面それぞれからタブを閉じて離脱
- 招待URLで再接続

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->
- Prepare画面への復帰は、Roomステータスの管理箇所を増やさないように `ステータスがWAITING && roundsが存在する` という判定で実装しました。

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [x] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
