### PR TITLE
fix: websocket error, browser back

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,8 @@
 import {
-	BrowserRouter,
-	Routes,
-	Route,
+	createBrowserRouter,
 	Outlet,
 	Navigate,
+	RouterProvider,
 	useParams,
 } from "react-router-dom";
 import "./App.css";
@@ -29,76 +28,71 @@ const RoomsRedirect = () => {
 	return <Navigate to={roomId ? `/waiting/${roomId}` : "/"} replace />;
 };
 
+const router = createBrowserRouter([
+	{
+		path: "/login",
+		element: (
+			<RequireGuest>
+				<Login />
+			</RequireGuest>
+		),
+	},
+	{
+		path: "/login/redirect",
+		element: (
+			<RequireGuest>
+				<RedirectLogin />
+			</RequireGuest>
+		),
+	},
+	{
+		path: "/register",
+		element: (
+			<RequireGuest>
+				<AccountRegister />
+			</RequireGuest>
+		),
+	},
+	{
+		path: "/password-reset/send-mail",
+		element: (
+			<RequireGuest>
+				<PasswordResetSendMail />
+			</RequireGuest>
+		),
+	},
+	{
+		path: "/password-reset",
+		element: (
+			<RequireGuest>
+				<PasswordReset />
+			</RequireGuest>
+		),
+	},
+	{
+		path: "/",
+		element: (
+			<RequireAuth>
+				<Outlet />
+			</RequireAuth>
+		),
+		children: [
+			{ index: true, element: <Home /> },
+			{ path: "rooms/:roomId", element: <RoomsRedirect /> },
+			{ path: "waiting/:id", element: <Waiting /> },
+			{ path: "prepare/:id", element: <Prepare /> },
+			{ path: "game/:id", element: <Game /> },
+			{ path: "result/:id", element: <Result /> },
+			{ path: "profile", element: <Profile /> },
+			{ path: "setup-profile", element: <SetupProfile /> },
+		],
+	},
+	{ path: "/terms", element: <TermsOfService /> },
+	{ path: "/privacy-policy", element: <PrivacyPolicy /> },
+]);
+
 const App = () => {
-	return (
-		<BrowserRouter>
-			<Routes>
-				{/* 未ログインの場合に表示するページ */}
-				<Route
-					path="/login"
-					element={
-						<RequireGuest>
-							<Login />
-						</RequireGuest>
-					}
-				/>
-				<Route
-					path="/login/redirect"
-					element={
-						<RequireGuest>
-							<RedirectLogin />
-						</RequireGuest>
-					}
-				/>
-				<Route
-					path="/register"
-					element={
-						<RequireGuest>
-							<AccountRegister />
-						</RequireGuest>
-					}
-				/>
-				<Route
-					path="/password-reset/send-mail"
-					element={
-						<RequireGuest>
-							<PasswordResetSendMail />
-						</RequireGuest>
-					}
-				/>
-				<Route
-					path="/password-reset"
-					element={
-						<RequireGuest>
-							<PasswordReset />
-						</RequireGuest>
-					}
-				/>
-
-				{/* ↓未ログイン状態でアクセスした場合、ログイン画面にリダイレクトされるページ */}
-				<Route
-					path="/"
-					element={
-						<RequireAuth>
-							<Outlet />
-						</RequireAuth>
-					}
-				>
-					<Route index element={<Home />} />
-					<Route path="rooms/:roomId" element={<RoomsRedirect />} />
-					<Route path="waiting/:id" element={<Waiting />} />
-					<Route path="prepare/:id" element={<Prepare />} />
-					<Route path="game/:id" element={<Game />} />
-					<Route path="result/:id" element={<Result />} />
-					<Route path="profile" element={<Profile />} />
-					<Route path="setup-profile" element={<SetupProfile />} />
-				</Route>
-
-				<Route path="/terms" element={<TermsOfService />} />
-				<Route path="/privacy-policy" element={<PrivacyPolicy />} />
-			</Routes>
-		</BrowserRouter>
-	);
+	return <RouterProvider router={router} />;
 };
 
 export default App;

--- a/frontend/src/features/auth/RequireAuth.tsx
+++ b/frontend/src/features/auth/RequireAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useBlocker, useLocation } from "react-router-dom";
 import Footer from "../../components/footer/Footer";
 import { useAuth } from "./useAuth";
 
@@ -12,6 +12,23 @@ const RequireAuth = ({ children }: { children: ReactNode }) => {
 
 	const redirectEnabled =
 		import.meta.env.VITE_AUTH_REDIRECT_ENABLED === "true";
+
+	// Prepare/Game/Result でブラウザ戻るを無効化（useBlocker は POP を検知してブロック）
+	const blocker = useBlocker(({ currentLocation, historyAction }) => {
+		const path = currentLocation.pathname + currentLocation.search;
+		const isPreventBackPage =
+			path.startsWith("/prepare/") ||
+			path.startsWith("/game/") ||
+			path.startsWith("/result/");
+		return isPreventBackPage && historyAction === "POP";
+	});
+
+	// ブロックされたら reset でその場に留める（確認UIは出さない）
+	useEffect(() => {
+		if (blocker.state === "blocked") {
+			blocker.reset();
+		}
+	}, [blocker.state]);
 
 	useEffect(() => {
 		// すでに認証済み、または初期化済み、または確認中なら何もしない

--- a/frontend/src/pages/Prepare.tsx
+++ b/frontend/src/pages/Prepare.tsx
@@ -32,14 +32,14 @@ const Prepare = () => {
 	// WebSocketの作成
 	useEffect(() => {
 		if (roomId === undefined || user?.id === undefined) return;
-		// WebSocketの作成
+		const closedByCleanup = { current: false };
 		const ws = createWebSocket();
 
 		ws.onopen = () => {
 			ws.send(
 				JSON.stringify({
 					type: "join",
-					userId: user.id,
+					userId: Number(user.id),
 					roomId: String(roomId),
 				}),
 			);
@@ -56,7 +56,7 @@ const Prepare = () => {
 								: p,
 						),
 					);
-					if (Number(data.userId) === user?.id) {
+					if (Number(data.userId) === Number(user?.id)) {
 						setIsReady(data.isReady);
 					}
 				}
@@ -71,11 +71,22 @@ const Prepare = () => {
 			}
 		};
 
-		ws.onerror = error => console.error("Websocket error:", error);
-		ws.onclose = () => console.log("Websocket disconnected");
+		ws.onerror = error => {
+			if (!closedByCleanup.current) {
+				console.error("Websocket error:", error);
+			}
+		};
+
+		ws.onclose = () => {
+			if (!closedByCleanup.current) {
+				console.log("Websocket disconnected");
+			}
+		};
+
 		queueMicrotask(() => setSocket(ws));
 
 		return () => {
+			closedByCleanup.current = true;
 			ws.close();
 			setSocket(null);
 		};

--- a/frontend/src/pages/Waiting.tsx
+++ b/frontend/src/pages/Waiting.tsx
@@ -98,6 +98,8 @@ const Waiting = () => {
 			reconnectTimeoutRef.current = null;
 		}
 
+		const closedByCleanupRef = { current: false };
+
 		const connect = () => {
 			if (reconnectTimeoutRef.current) {
 				clearTimeout(reconnectTimeoutRef.current);
@@ -107,6 +109,7 @@ const Waiting = () => {
 				socketRef.current.close();
 				socketRef.current = null;
 			}
+			closedByCleanupRef.current = false;
 			const ws = createWebSocket();
 
 			ws.onopen = () => {
@@ -177,6 +180,7 @@ const Waiting = () => {
 			};
 
 			ws.onerror = error => {
+				if (closedByCleanupRef.current) return;
 				if (ws.readyState !== WebSocket.OPEN) {
 					console.warn(
 						"WebSocket connection error (may retry):",
@@ -188,6 +192,7 @@ const Waiting = () => {
 			};
 
 			ws.onclose = () => {
+				if (closedByCleanupRef.current) return;
 				if (!isMountedRef.current) return;
 				// このソケットが既に置き換えられている場合は再接続しない
 				if (socketRef.current !== ws) return;
@@ -233,6 +238,7 @@ const Waiting = () => {
 
 		return () => {
 			isMountedRef.current = false;
+			closedByCleanupRef.current = true;
 			if (reconnectTimeoutRef.current) {
 				clearTimeout(reconnectTimeoutRef.current);
 				reconnectTimeoutRef.current = null;


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
- ブラウザバックの対応とWebSocketエラーの修正
## 変更内容
| ファイル | 主な変更内容 |
|---|---|
| `App.tsx` | `BrowserRouter + Routes` → `createBrowserRouter + RouterProvider` への移行 |
| `RequireAuth.tsx` | `useBlocker` で Prepare / Game / Result でのブラウザバックをブロック |
| `Prepare.tsx` | クリーンアップ時の WebSocket エラー/切断ログを抑制、`userId` の型を `Number` に統一 |
| `Waiting.tsx` | クリーンアップ時の WebSocket エラー/切断ログを抑制 |
## テスト <!-- どのように確認(テスト)すればいいですか？ -->
画面遷移後にすぐブラウザバックを押すとできるので少し待ってから押してください
- [ ] Prepare 画面でブラウザバック → 遷移せずそのまま
- [ ] Game 画面でブラウザバック → 遷移せずそのまま
- [ ] Result 画面でブラウザバック → 遷移せずそのまま
- [ ] Prepare 画面から別画面へ遷移したとき、コンソールに不要な WebSocket エラー/切断ログが出ない
- [ ] Waiting 画面から別画面へ遷移したとき、同様に不要なログが出ない
- [ ] 通常のネットワークエラー時には、これまで通りログが出る

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [x] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
