### PR TITLE
🛠️ 観戦者は、準備完了ボタン出ないようにした

### DIFF
--- a/frontend/src/pages/Prepare.tsx
+++ b/frontend/src/pages/Prepare.tsx
@@ -236,8 +236,7 @@ const Prepare = () => {
 									avatar={avatarOrDefault(
 										currentDrawer?.avatar,
 									)}
-									size="lg"
-									className="w-full h-full"
+									size="md"
 								/>
 								<p
 									className="text-2xl font-bold"


### PR DESCRIPTION
## 概要 <!-- このPRで何を実装/修正したか -->
-  観戦者は、準備完了ボタン出ないようにした
- 観戦者の役割を「観戦者」になるようにした
- ついでに、「今回の描き手」のアイコン画像を小さくした

## 変更内容

- 変更1
- 変更2

## テスト <!-- どのように確認(テスト)すればいいですか？ -->
1. 起動
```bash
make down
make
```
2. ３ウィンドウでそれぞれログインし、ルームを作成後、このうち１人を観戦者にする

## レビューポイント <!-- レビュアーに特に見てほしい箇所 -->

## その他 <!-- レビュワーに伝えたい補足事項や懸念点があれば -->

### PR出す際の確認事項 <!-- このPRを出す前に、再度確認してください。 -->

- [ ] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
- [ ] コーディング規約に沿ってますか？[詳細](https://www.notion.so/2ec413dc637e80fcbd0defccdae75547)
